### PR TITLE
Wording inception in email wordings

### DIFF
--- a/mails/themes/modern_mjml/components/footer.mjml.twig
+++ b/mails/themes/modern_mjml/components/footer.mjml.twig
@@ -7,7 +7,7 @@
       <a href="{shop_url}" style="color:#656565;font-size:16px;font-weight:600;">{shop_name}</a>
     </mj-text>
     <mj-text padding-top="0" align="center" color="#656565" font-size="12px">
-      Powered by <a href="https://www.prestashop.com/?utm_source=marchandprestashop&utm_medium=e-mail=utm_campaign=footer_1-7" style="color:#656565;font-weight:400;">PrestaShop</a>
+      Powered by <a href="https://www.prestashop.com/?utm_source=marchandprestashop&utm_medium=e-mail&utm_campaign=footer_1-7" style="color:#656565;font-weight:400;">PrestaShop</a>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/bankwire.mjml.twig
+++ b/mails/themes/modern_mjml/core/bankwire.mjml.twig
@@ -122,7 +122,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
     <mj-column>
-        <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+        <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
     </mj-column>
 </mj-section>
 <mj-raw>
@@ -135,7 +135,7 @@
 <mj-section padding="0 25px">
     <mj-column>
         <mj-text padding-top="0">
-            {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+            {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
         </mj-text>
     </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/cheque.mjml.twig
+++ b/mails/themes/modern_mjml/core/cheque.mjml.twig
@@ -118,7 +118,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
     <mj-column>
-        <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+        <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
     </mj-column>
 </mj-section>
 <mj-raw>
@@ -131,7 +131,7 @@
 <mj-section padding="0 25px">
     <mj-column>
         <mj-text padding-top="0">
-            {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+            {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
         </mj-text>
     </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/credit_slip.mjml.twig
+++ b/mails/themes/modern_mjml/core/credit_slip.mjml.twig
@@ -66,7 +66,7 @@
 <mj-section padding="0 25px 30px">
     <mj-column>
         <mj-text>
-            {{ 'Review this credit slip and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Credit slips</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}
+            {{ 'Review this credit slip and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%credit_slips_label%</a> section of your customer account.'|trans({'%credit_slips_label%': 'Credit slips'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
         </mj-text>
     </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/download_product.mjml.twig
+++ b/mails/themes/modern_mjml/core/download_product.mjml.twig
@@ -78,7 +78,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
     <mj-column>
-        <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+        <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
     </mj-column>
 </mj-section>
 <mj-raw>
@@ -91,7 +91,7 @@
 <mj-section padding="0 25px">
     <mj-column>
         <mj-text padding-top="0">
-            {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+            {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
         </mj-text>
     </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/in_transit.mjml.twig
+++ b/mails/themes/modern_mjml/core/in_transit.mjml.twig
@@ -70,7 +70,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
   <mj-column>
-    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-raw>
@@ -83,7 +83,7 @@
 <mj-section padding="0 25px">
   <mj-column>
     <mj-text padding-top="0">
-      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/order_canceled.mjml.twig
+++ b/mails/themes/modern_mjml/core/order_canceled.mjml.twig
@@ -67,7 +67,7 @@
 <mj-section padding="0 25px">
   <mj-column>
     <mj-text padding-top="0">
-      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/order_changed.mjml.twig
+++ b/mails/themes/modern_mjml/core/order_changed.mjml.twig
@@ -68,7 +68,7 @@
 <mj-section padding="0 25px">
   <mj-column>
     <mj-text padding-top="0">
-      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/order_conf.mjml.twig
+++ b/mails/themes/modern_mjml/core/order_conf.mjml.twig
@@ -248,7 +248,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
   <mj-column>
-    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-raw>
@@ -261,7 +261,7 @@
 <mj-section padding="0 25px">
   <mj-column>
     <mj-text padding-top="0">
-      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/order_return_state.mjml.twig
+++ b/mails/themes/modern_mjml/core/order_return_state.mjml.twig
@@ -65,7 +65,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
   <mj-column>
-    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-raw>

--- a/mails/themes/modern_mjml/core/outofstock.mjml.twig
+++ b/mails/themes/modern_mjml/core/outofstock.mjml.twig
@@ -74,7 +74,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
   <mj-column>
-    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-raw>
@@ -87,7 +87,7 @@
 <mj-section padding="0 25px">
   <mj-column>
     <mj-text padding-top="0">
-      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/payment.mjml.twig
+++ b/mails/themes/modern_mjml/core/payment.mjml.twig
@@ -64,7 +64,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
   <mj-column>
-    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-raw>
@@ -77,7 +77,7 @@
 <mj-section padding="0 25px">
   <mj-column>
     <mj-text padding-top="0">
-      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/payment_error.mjml.twig
+++ b/mails/themes/modern_mjml/core/payment_error.mjml.twig
@@ -67,7 +67,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
   <mj-column>
-    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-raw>
@@ -80,7 +80,7 @@
 <mj-section padding="0 25px">
   <mj-column>
     <mj-text padding-top="0">
-      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/preparation.mjml.twig
+++ b/mails/themes/modern_mjml/core/preparation.mjml.twig
@@ -64,7 +64,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
   <mj-column>
-    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-raw>
@@ -77,7 +77,7 @@
 <mj-section padding="0 25px">
   <mj-column>
     <mj-text padding-top="0">
-      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/refund.mjml.twig
+++ b/mails/themes/modern_mjml/core/refund.mjml.twig
@@ -60,7 +60,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
   <mj-column>
-    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-raw>
@@ -73,7 +73,7 @@
 <mj-section padding="0 25px">
   <mj-column>
     <mj-text padding-top="0">
-      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/core/shipped.mjml.twig
+++ b/mails/themes/modern_mjml/core/shipped.mjml.twig
@@ -64,7 +64,7 @@
 </mj-raw>
 <mj-section padding="0 25px 20px">
   <mj-column>
-    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">Order history and details</a> section of your customer account.'|trans({}, 'Emails.Body', locale)|raw }}</mj-text>
+    <mj-text>{{ 'Follow your order and download your invoice on our shop, go to the <a href="{history_url}" target="_blank">%order_history_label%</a> section of your customer account.'|trans({'%order_history_label%': 'Order history and details'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}</mj-text>
   </mj-column>
 </mj-section>
 <mj-raw>
@@ -77,7 +77,7 @@
 <mj-section padding="0 25px">
   <mj-column>
     <mj-text padding-top="0">
-      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/mails/themes/modern_mjml/modules/ps_emailalerts/order_changed.mjml.twig
+++ b/mails/themes/modern_mjml/modules/ps_emailalerts/order_changed.mjml.twig
@@ -69,7 +69,7 @@
 <mj-section padding="0 25px 20px">
   <mj-column>
     <mj-text>
-      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">Guest Tracking</a> section on our shop.'|trans({}, 'Emails.Body', locale)|raw }}
+      {{ 'If you have a guest account, you can follow your order via the <a href="{guest_tracking_url}" target="_blank">%guest_tracking_label%</a> section on our shop.'|trans({'%guest_tracking_label%': 'Guest Tracking'|trans({}, 'Shop.Theme.Customeraccount', locale)}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/src/AppBundle/Converter/TwigTemplateConverter.php
+++ b/src/AppBundle/Converter/TwigTemplateConverter.php
@@ -109,7 +109,12 @@ class TwigTemplateConverter
         $head = $dom->getElementsByTagName('head')->item(0);
         $head->appendChild($blockNode);
 
-        return $dom->saveHTML();
+        $html = $dom->saveHTML();
+
+        // Since DOMDocument::saveHTML converts special characters into special HTML characters we revert them back
+        $html = htmlspecialchars_decode($html);
+
+        return $html;
     }
 
     public function convertComponentTemplate($mjmlTemplatePath, $mjmlTheme, $newTheme)
@@ -244,6 +249,9 @@ $layoutStyles
             $filteredContent .= $domElement->ownerDocument->saveHTML($domElement);
         }
 
+        // Since DOMDocument::saveHTML converts special characters into special HTML characters we revert them back
+        $filteredContent = htmlspecialchars_decode($filteredContent);
+
         return $filteredContent;
     }
 
@@ -272,6 +280,9 @@ $layoutStyles
         foreach ($nodeList as $childNode) {
             $extractedHtml .= $childNode->ownerDocument->saveHTML($childNode);
         }
+
+        // Since DOMDocument::saveHTML converts special characters into special HTML characters we revert them back
+        $extractedHtml = htmlspecialchars_decode($extractedHtml);
 
         return $extractedHtml;
     }


### PR DESCRIPTION
Related to this core issue https://github.com/PrestaShop/PrestaShop/issues/18809

Some wordings include other wordings, so we introduced some placeholders into them to allow injecting the translated text Since the modern them had some of them we need to update its sources in this repository

Also fix a bug that always converted `>` into `&gt;` in the wordings