### PR TITLE
Fix invalid html in order_conf template

### DIFF
--- a/mails/themes/modern_mjml/core/order_conf.mjml.twig
+++ b/mails/themes/modern_mjml/core/order_conf.mjml.twig
@@ -95,11 +95,25 @@
         <th bgcolor="#FDFDFD">{{ 'Total price'|trans({}, 'Emails.Body', locale)|raw }}</th>
       </tr>
 
-      <html-only>{products}</html-only>
-      <txt-only>{products_txt}</txt-only>
+      <!-- delete -->
+      <tr>
+        <td style="border:1px solid #D6D4D4;padding:7px 0;text-align:center;" colspan="5">
+          <!-- /delete -->
+          <html-only>{products}</html-only>
+          <txt-only>{products_txt}</txt-only>
+          <!-- delete -->
+        </td>
+      </tr>
 
-      <html-only>{discounts}</html-only>
-      <txt-only>{discounts_txt}</txt-only>
+      <tr class="conf_body">
+        <td bgcolor="#f8f8f8" colspan="5" style="border:1px solid #D6D4D4;color:#333;padding:7px 0;text-align:center;">
+          <!-- /delete -->
+          <html-only>{discounts}</html-only>
+          <txt-only>{discounts_txt}</txt-only>
+          <!-- delete -->
+        </td>
+      </tr>
+      <!-- /delete -->
 
       <tr class="order_summary">
         <td bgcolor="#FDFDFD" colspan="3" align="right">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `{products}` & `{discounts}` variables in the `order_conf` were not in an valid html node, leading tinymce to move those variables in another place in the html code.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no

⚠️ This should be merged only when https://github.com/PrestaShop/PrestaShop/pull/21798 is merged.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
