### PR TITLE
It's an email for the shop not for customer

### DIFF
--- a/mails/themes/modern_mjml/core/log_alert.mjml.twig
+++ b/mails/themes/modern_mjml/core/log_alert.mjml.twig
@@ -10,7 +10,7 @@
       <!-- TITLE BEGINING -->
     </mj-raw>
     <mj-text padding-top="0" padding-bottom="20px" font-weight="600" font-size="20px">
-      {{ 'Hi {firstname} {lastname},'|trans({}, 'Emails.Body', locale) }}
+      {{ 'Hi,'|trans({}, 'Emails.Body', locale) }}
     </mj-text>
     <mj-raw>
       <!-- TITLE ENDING -->


### PR DESCRIPTION
It's an email for shop not customer

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      |It's an email for shop not customer
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| How to test?      | Check if {firstname} {lastname},  are present
| Possible impacts? | No impact

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

After ps_metrics bug i recive a lot of mails but it's for the shop not for the customer

![Capture d’écran de 2021-04-15 15-49-11](https://user-images.githubusercontent.com/5064590/114880276-374f5000-9e02-11eb-8765-0a20b00e08e4.png)

