### PR TITLE
Fixed Modern email theme for RTL languages

### DIFF
--- a/mails/themes/modern_mjml/assets/rtl.css
+++ b/mails/themes/modern_mjml/assets/rtl.css
@@ -20,3 +20,8 @@ div {
     margin-right: 0 !important;
     margin-left: 10px;
 }
+
+.order_summary td:first-child,
+.conf_body td:first-child > table td {
+    text-align: left !important;
+}

--- a/mails/themes/modern_mjml/assets/rtl.css
+++ b/mails/themes/modern_mjml/assets/rtl.css
@@ -1,0 +1,22 @@
+
+div {
+    direction: rtl !important;
+    text-align: right !important;
+}
+
+.header td table {
+    margin: 0 auto;
+}
+
+.mj-column-px-25 {
+    float: right;
+}
+
+.footer div {
+    text-align: center !important;
+}
+
+.subtitle-icon {
+    margin-right: 0 !important;
+    margin-left: 10px;
+}

--- a/mails/themes/modern_mjml/components/footer.mjml.twig
+++ b/mails/themes/modern_mjml/components/footer.mjml.twig
@@ -1,7 +1,7 @@
 <mj-raw>
   <!-- SHOP NAME BEGINING -->
 </mj-raw>
-<mj-section>
+<mj-section css-class="footer">
   <mj-column>
     <mj-text align="center">
       <a href="{shop_url}" style="color:#656565;font-size:16px;font-weight:600;">{shop_name}</a>

--- a/mails/themes/modern_mjml/components/header.mjml.twig
+++ b/mails/themes/modern_mjml/components/header.mjml.twig
@@ -1,7 +1,7 @@
 <mj-raw>
   <!-- LOGO BEGINING -->
 </mj-raw>
-<mj-section padding="45px 25px">
+<mj-section css-class="header" padding="45px 25px">
   <mj-column>
     <mj-image width="150px" align="left" src="{shop_logo}" href="{shop_url}" />
   </mj-column>

--- a/mails/themes/modern_mjml/core/order_conf.mjml.twig
+++ b/mails/themes/modern_mjml/core/order_conf.mjml.twig
@@ -163,7 +163,7 @@
 <mj-section padding="0 50px 0" text-align="left">
   <mj-column padding="0">
     <mj-text padding="0" font-weight="600" font-size="16px">
-      <img src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-local_shipping-24px.png" style="margin-right:10px" />
+      <img class="subtitle-icon" src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-local_shipping-24px.png" style="margin-right:10px" />
       {{ 'Shipping'|trans({}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
@@ -205,7 +205,7 @@
             <tr>
               <td>
                 <p style="font-weight:600;">
-                  <img src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-location_on-24px.png" style="width:15px;margin-right:10px">
+                  <img class="subtitle-icon" src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-location_on-24px.png" style="width:15px;margin-right:10px">
                   {{ 'Delivery address'|trans({}, 'Emails.Body', locale)|raw }}
                 </p>
                 <p style="border: 1px solid #DFDFDF;background-color: #FEFEFE;padding:20px;font-size:14px">
@@ -225,7 +225,7 @@
 
               <td>
                 <p style="font-weight:600;">
-                  <img src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-credit_card-24px.png" style="width:25px;margin-right:10px">
+                  <img class="subtitle-icon" src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-credit_card-24px.png" style="width:25px;margin-right:10px">
                   {{ 'Billing address'|trans({}, 'Emails.Body', locale)|raw }}
                 </p>
                 <p style="border: 1px solid #DFDFDF;background-color: #FEFEFE;padding:20px;font-size:14px">

--- a/mails/themes/modern_mjml/modules/ps_emailalerts/new_order.mjml.twig
+++ b/mails/themes/modern_mjml/modules/ps_emailalerts/new_order.mjml.twig
@@ -162,7 +162,7 @@
 <mj-section padding="0 50px 0" text-align="left">
   <mj-column padding="0">
     <mj-text padding="0" font-weight="600" font-size="16px">
-      <img src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-local_shipping-24px.png" style="margin-right:10px" />
+      <img class="subtitle-icon" src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-local_shipping-24px.png" style="margin-right:10px" />
       {{ 'Carrier'|trans({}, 'Emails.Body', locale)|raw }}
     </mj-text>
   </mj-column>
@@ -201,7 +201,7 @@
             <tr>
               <td>
                 <p style="font-weight:600;">
-                  <img src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-location_on-24px.png" style="width:15px;margin-right:10px">
+                  <img class="subtitle-icon" src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-location_on-24px.png" style="width:15px;margin-right:10px">
                   {{ 'Delivery address'|trans({}, 'Emails.Body', locale)|raw }}
                 </p>
                 <p style="border: 1px solid #DFDFDF;background-color: #FEFEFE;padding:20px;font-size:14px">
@@ -220,7 +220,7 @@
 
               <td>
                 <p style="font-weight:600;">
-                  <img src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-credit_card-24px.png" style="width:25px;margin-right:10px">
+                  <img class="subtitle-icon" src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-credit_card-24px.png" style="width:25px;margin-right:10px">
                   {{ 'Billing address'|trans({}, 'Emails.Body', locale)|raw }}
                 </p>
                 <p style="border: 1px solid #DFDFDF;background-color: #FEFEFE;padding:20px;font-size:14px">

--- a/mails/themes/modern_mjml/modules/ps_emailalerts/return_slip.mjml.twig
+++ b/mails/themes/modern_mjml/modules/ps_emailalerts/return_slip.mjml.twig
@@ -115,7 +115,7 @@
             <tr>
               <td>
                 <p style="font-weight:600;">
-                  <img src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-location_on-24px.png" style="width:15px;margin-right:10px">
+                  <img class="subtitle-icon" src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-location_on-24px.png" style="width:15px;margin-right:10px">
                   {{ 'Delivery address'|trans({}, 'Emails.Body', locale)|raw }}
                 </p>
                 <p style="border: 1px solid #DFDFDF;background-color: #FEFEFE;padding:20px;font-size:14px">
@@ -134,7 +134,7 @@
 
               <td>
                 <p style="font-weight:600;">
-                  <img src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-credit_card-24px.png" style="width:25px;margin-right:10px">
+                  <img class="subtitle-icon" src="{{ mailThemesUrl }}/modern_mjml/assets/baseline-credit_card-24px.png" style="width:25px;margin-right:10px">
                   {{ 'Billing address'|trans({}, 'Emails.Body', locale)|raw }}
                 </p>
                 <p style="border: 1px solid #DFDFDF;background-color: #FEFEFE;padding:20px;font-size:14px">

--- a/src/AppBundle/Converter/TwigTemplateConverter.php
+++ b/src/AppBundle/Converter/TwigTemplateConverter.php
@@ -113,6 +113,12 @@ class TwigTemplateConverter
         $head->insertBefore($blockStyleStart, $style);
         $head->appendChild($blockStyleEnd);
 
+        //Add inline CSS for RTL languages
+        $link = $dom->createTextNode("{% if languageIsRTL %}\n  ".
+            "<style type=\"text/css\">{% include '@MailThemes/modern/assets/rtl.css' %}</style>\n  ".
+            "{% endif %}\n  ");
+        $head->insertBefore($link, $blockStyleStart);
+        
         $html = $dom->saveHTML();
 
         // Since DOMDocument::saveHTML converts special characters into special HTML characters we revert them back


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix text align and text direction in Modern email template for RTL languages.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/26177
| How to test?      | 1. Go to BO > Design >  Email Theme <br/>2. Choose `modern` for preview
| Possible impacts? | RTL version of Modern email theme.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

![Screenshot-2021-12-17-at-20-27-30-Order-confirmation](https://user-images.githubusercontent.com/85633460/146582069-f9a98f97-fa63-4862-9f2e-60c226f6168a.jpg)
