### PR TITLE
Remove link tags generated by mjml.

### DIFF
--- a/src/AppBundle/Converter/TwigTemplateConverter.php
+++ b/src/AppBundle/Converter/TwigTemplateConverter.php
@@ -223,6 +223,7 @@ $layoutStyles
         $htmlHead = $this->extractHtml($convertedTemplate, 'head');
         if (preg_match('#(<style.*</style>)#s', $htmlHead, $matches)) {
             $templateStyles = trim($matches[1])."\n";
+            $templateStyles = preg_replace('/\s*<link[^>]*>/i', '', $templateStyles);
         } else {
             $templateStyles = '';
         }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Removing `<link>` tags in the head, in order to be able to test with `maildev`
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #18.
| How to test?      | Send mail with the generated mail templates, and open them with `maildev`. The height of the mail view is adjusted to the window. This was not the case without the fix.
| Possible impacts? | including webfonts with `<link` tag is only used on old email clients as a fallback for CSS `@imports` rules.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
