### PR TITLE
Fixed RTL issues for modern email theme 

### DIFF
--- a/mails/themes/modern_mjml/components/header.mjml.twig
+++ b/mails/themes/modern_mjml/components/header.mjml.twig
@@ -3,7 +3,7 @@
 </mj-raw>
 <mj-section padding="45px 25px">
   <mj-column>
-    <mj-image width="150px" align="left" src="{shop_logo}" href="{shop_url}" />
+    <mj-image width="150px" align="center" src="{shop_logo}" href="{shop_url}" />
   </mj-column>
 </mj-section>
 <mj-raw>

--- a/src/AppBundle/Command/ConvertMJMLThemeCommand.php
+++ b/src/AppBundle/Command/ConvertMJMLThemeCommand.php
@@ -114,6 +114,8 @@ class ConvertMJMLThemeCommand extends Command
                 $fileSystem->mkdir($twigTemplateFolder);
             }
 
+            $twigTemplate = $this->converter->convertRTL($twigTemplate);
+            
             file_put_contents($twigTemplatePath, $twigTemplate);
         }
 

--- a/src/AppBundle/Converter/TwigTemplateConverter.php
+++ b/src/AppBundle/Converter/TwigTemplateConverter.php
@@ -112,7 +112,19 @@ class TwigTemplateConverter
         $style = $head->getElementsByTagName('style')->item(0);
         $head->insertBefore($blockStyleStart, $style);
         $head->appendChild($blockStyleEnd);
-
+        
+        //Add RTL condition in twig layouts
+        $link = $dom->createTextNode(
+            "{% set direction = 'ltr' %}\n  ".
+            "{% set align_left = 'left' %}\n  ".
+            "{% set align_right = 'right' %}\n  ".
+            "{% if languageIsRTL|default(false) %}\n  ".
+            "{% set direction = 'rtl' %}\n  ".
+            "{% set align_left = 'right' %}\n  ".
+            "{% set align_right = 'left' %}\n  ".
+            "{% endif %}\n  ");
+        $head->insertBefore($link, $blockStyleStart);
+        
         $html = $dom->saveHTML();
 
         // Since DOMDocument::saveHTML converts special characters into special HTML characters we revert them back
@@ -178,6 +190,17 @@ $layoutContent
 $layoutStyles
 {% endblock %}
 ";
+    }
+
+    public function convertRTL($twigTemplate)
+    {
+        $twigTemplate = preg_replace('/direction:ltr/', 'direction:{{ direction }}', $twigTemplate);
+        $twigTemplate = preg_replace('/align="left"/', 'align="{{ align_left }}"', $twigTemplate);
+        $twigTemplate = preg_replace('/text-align:left/', 'text-align:{{ align_left }}', $twigTemplate);
+        $twigTemplate = preg_replace('/align="right"/', 'align="{{ align_right }}"', $twigTemplate);
+        $twigTemplate = preg_replace('/margin-right:/', 'margin-{{ align_right }}:', $twigTemplate);
+
+        return $twigTemplate;
     }
 
     /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix text align and text direction in modern email template for RTL languages.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/26177
| How to test?      | 1. Go to BO > Design >  Email Theme <br/>2. Choose `modern` for preview
| Possible impacts? | RTL version of modern email theme. 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
