### PR TITLE
Related PR #27890, add check if the gift wrapping is enabled or disabled (show or hide the related html block)

### DIFF
--- a/mails/themes/modern_mjml/core/order_conf.mjml.twig
+++ b/mails/themes/modern_mjml/core/order_conf.mjml.twig
@@ -117,6 +117,7 @@
           {total_discounts}
         </td>
       </tr>
+      <mj-addif condition="giftWrapping == 1">
       <tr class="order_summary">
         <td bgcolor="#FDFDFD" colspan="3" align="right">
           {{ 'Gift-wrapping'|trans({}, 'Emails.Body', locale)|raw }}
@@ -125,6 +126,7 @@
           {total_wrapping}
         </td>
       </tr>
+      </mj-addif>
       <tr class="order_summary">
         <td bgcolor="#FDFDFD" colspan="3" align="right">
           {{ 'Shipping'|trans({}, 'Emails.Body', locale)|raw }}

--- a/mails/themes/modern_mjml/core/order_conf.mjml.twig
+++ b/mails/themes/modern_mjml/core/order_conf.mjml.twig
@@ -117,7 +117,7 @@
           {total_discounts}
         </td>
       </tr>
-      <mj-addif condition="giftWrapping == 1">
+      <twig-if condition="giftWrapping == 1">
       <tr class="order_summary">
         <td bgcolor="#FDFDFD" colspan="3" align="right">
           {{ 'Gift-wrapping'|trans({}, 'Emails.Body', locale)|raw }}
@@ -126,7 +126,7 @@
           {total_wrapping}
         </td>
       </tr>
-      </mj-addif>
+      </twig-if>
       <tr class="order_summary">
         <td bgcolor="#FDFDFD" colspan="3" align="right">
           {{ 'Shipping'|trans({}, 'Emails.Body', locale)|raw }}

--- a/src/AppBundle/Converter/TwigTemplateConverter.php
+++ b/src/AppBundle/Converter/TwigTemplateConverter.php
@@ -294,6 +294,44 @@ $layoutStyles
 
         return $filteredContent;
     }
+    
+    /**
+     * @param string $templateContent
+     * @param string $containerSelector
+     *
+     * @return string
+     */
+    private function replaceContainerWithTwigIfCondition($templateContent, string $containerSelector)
+    {
+        $crawler = new Crawler($templateContent);
+
+        $crawler->filter($containerSelector)->each(function (Crawler $crawler) {
+            foreach ($crawler as $node) {
+                $replaceNodes = [];
+                $replaceNodes[] = $node->ownerDocument->createTextNode(PHP_EOL .'{% if '. $node->attributes->getNamedItem('condition')->nodeValue .' %}' . PHP_EOL);
+                /** @var DOMElement $childNode */
+                foreach ($node->childNodes as $childNode) {
+                    $replaceNodes[] = $childNode->cloneNode(true);
+                }
+                $replaceNodes[] = $node->ownerDocument->createTextNode(PHP_EOL . '{% endif %}' . PHP_EOL);
+
+                foreach ($replaceNodes as $childNode) {
+                    $node->parentNode->insertBefore($childNode, $node);
+                }
+                $node->parentNode->removeChild($node);
+            }
+        });
+
+        $filteredContent = '';
+        foreach ($crawler as $domElement) {
+            $filteredContent .= $domElement->ownerDocument->saveHTML($domElement);
+        }
+
+        // Since DOMDocument::saveHTML converts special characters into special HTML characters we revert them back
+        $filteredContent = htmlspecialchars_decode($filteredContent);
+
+        return $filteredContent;
+    }
 
     /**
      * @param string $htmlContent
@@ -305,6 +343,7 @@ $layoutStyles
     {
         $htmlContent = $this->replaceContainerWithTwigCondition($htmlContent, 'html-only', 'html');
         $htmlContent = $this->replaceContainerWithTwigCondition($htmlContent, 'txt-only', 'txt');
+        $htmlContent = $this->replaceContainerWithTwigIfCondition($htmlContent, 'mj-addif');
 
         //MJML returns a full html template, get only the body content
         $crawler = new Crawler($htmlContent);

--- a/src/AppBundle/Converter/TwigTemplateConverter.php
+++ b/src/AppBundle/Converter/TwigTemplateConverter.php
@@ -343,7 +343,7 @@ $layoutStyles
     {
         $htmlContent = $this->replaceContainerWithTwigCondition($htmlContent, 'html-only', 'html');
         $htmlContent = $this->replaceContainerWithTwigCondition($htmlContent, 'txt-only', 'txt');
-        $htmlContent = $this->replaceContainerWithTwigIfCondition($htmlContent, 'mj-addif');
+        $htmlContent = $this->replaceContainerWithTwigIfCondition($htmlContent, 'twig-if');
 
         //MJML returns a full html template, get only the body content
         $crawler = new Crawler($htmlContent);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adding the if condition to check if the gift wrapping option is enabled or not, and show or hide the related html block in the e-mail
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     |no
| Related PR?     | Related PR https://github.com/PrestaShop/PrestaShop/pull/27890
| How to test?      | Follow the instructions to compile the email theme

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

I didn't find a way to simply add the if to the mjml template, even if using the `<mj-raw>` tag, the compiler give me an error about the variable `giftWrapping`, that does not exists 🤷🏻‍♂️

I created a new method to convert a new custom tag `<mj-addif>` and correctly add the `if` condition in Twig code