### PR TITLE
Change PrestaShop URL in footer

### DIFF
--- a/mails/themes/modern_mjml/components/footer.mjml.twig
+++ b/mails/themes/modern_mjml/components/footer.mjml.twig
@@ -7,7 +7,7 @@
       <a href="{shop_url}" style="color:#656565;font-size:16px;font-weight:600;">{shop_name}</a>
     </mj-text>
     <mj-text padding-top="0" align="center" color="#656565" font-size="12px">
-      Powered by <a href="https://www.prestashop.com/?utm_source=marchandprestashop&utm_medium=e-mail&utm_campaign=footer_1-7" style="color:#656565;font-weight:400;">PrestaShop</a>
+      Powered by <a href="https://www.prestashop-project.org/" style="color:#656565;font-weight:400;">PrestaShop</a>
     </mj-text>
   </mj-column>
 </mj-section>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | According to Company/OS Project clarification, links in footer of emails should point to https://www.prestashop-project.org/ instead of https://www.prestashop.com/.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no

Partially fix https://github.com/PrestaShop/PrestaShop/issues/22311.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
